### PR TITLE
Use unsigned int instead of uint for cross-platform compatibility

### DIFF
--- a/fap.go
+++ b/fap.go
@@ -9,7 +9,7 @@ package fap
 char* str_at(char **lst, int idx) {
     return lst[idx];
 }
-char* new_c_str(uint size) {
+char* new_c_str(unsigned int size) {
     return (char*) malloc( size*sizeof(char) );
 }
 fap_packet_type_t* packet_type(fap_packet_t *p) {


### PR DESCRIPTION
The package yields a compile error on osx:

```
❯ go get -a github.com/martinhpedersen/libfap-go
# github.com/martinhpedersen/libfap-go
../../go/src/github.com/martinhpedersen/libfap-go/fap.go:12:17: error: unknown type name 'uint'; did you mean 'int'?
char* new_c_str(uint size) {
                ^~~~
                int
1 error generated.
```

I changed the concerned line to use `unsigned int` instead of `uint`.
